### PR TITLE
Introducing cleanup of individual packages and ensuring readability of update/cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN dnf -y install texlive \
                    texlive-tapir \
                    texlive-thmtools \
                    texlive-sansmathaccent \
-                   texlive-sectsty
+                   texlive-sectsty && \
+                   dnf clean all
+
 RUN dnf -y update && \
     dnf clean all
 RUN mkdir /workspace


### PR DESCRIPTION
Package installations downloads are committed to the layer as dnf clean is mentioned after dnf update which essentially forms another layer. With respect to readability, dnf update has not been merged with the individual package installations.